### PR TITLE
refactor(career_site): uses `sites` prefix for career site links

### DIFF
--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -21,7 +21,7 @@ class RodauthApp < Rodauth::Rails::App
     rodauth.load_memory # autologin remembered users
 
     # Ignore configuration for career site. We don't need to authenticate.
-    return if r.path.match?(%r{\A/(?!ats\b)\w+/positions(/|\z)})
+    return if r.path.start_with?("/sites/")
 
     # Ignore "remember" plugin's routes since we don't need them right now.
     r.is "remember" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,6 @@ Rails.application.routes.draw do
   end
 
   get "sites/:tenant_slug", to: "career_site/positions#index", as: "career_site_positions"
-  post "sites/:tenant_slug/positions/:position_id/apply", to: "career_site/positions#apply", as: "apply_career_site_position"
   get "sites/:tenant_slug/positions/:id", to: "career_site/positions#show", as: "career_site_position"
+  post "sites/:tenant_slug/positions/:position_id/apply", to: "career_site/positions#apply", as: "apply_career_site_position"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,7 +154,7 @@ Rails.application.routes.draw do
     mount Blazer::Engine, at: "stats"
   end
 
-  get ":tenant_slug/positions", to: "career_site/positions#index", as: "career_site_positions"
-  post ":tenant_slug/positions/:position_id/apply", to: "career_site/positions#apply", as: "apply_career_site_position"
-  get ":tenant_slug/positions/:id", to: "career_site/positions#show", as: "career_site_position"
+  get "sites/:tenant_slug", to: "career_site/positions#index", as: "career_site_positions"
+  post "sites/:tenant_slug/positions/:position_id/apply", to: "career_site/positions#apply", as: "apply_career_site_position"
+  get "sites/:tenant_slug/positions/:id", to: "career_site/positions#show", as: "career_site_position"
 end


### PR DESCRIPTION
Closes #76.

- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
