### PR TITLE
fix(ui): badge styles

### DIFF
--- a/app/assets/stylesheets/src/ats/_main.scss
+++ b/app/assets/stylesheets/src/ats/_main.scss
@@ -12,3 +12,7 @@
     padding-left: 0;
   }
 }
+
+.badge {
+  border-color: var(--tblr-gray-200);
+}

--- a/app/assets/stylesheets/src/shared/_components.scss
+++ b/app/assets/stylesheets/src/shared/_components.scss
@@ -243,9 +243,14 @@
     .item {
       padding-top: 0 !important;
       padding-bottom: 0 !important;
-      background-color: $gray-200 !important;
       margin: 0rem !important;
       border-radius: 4px !important;
+
+      // Tabler badge styles
+      background: var(--tblr-bg-surface-secondary) !important;
+      border: 1px solid var(--tblr-gray-200) !important;
+      color: var(--tblr-gray-500) !important;
+      font-weight: var(--tblr-font-weight-bold);
 
       .remove {
         border: none !important;


### PR DESCRIPTION
Closes #16.
Part of #114.


- [x] Set border-color to --tblr-gray-200 (#dce1e7).
- [x] [Pill select (i.e. Location and previously was Watchers for tasks) uses badges/tags with styles that doesn't match Tabler's](https://github.com/freeats/freeats/issues/114#issuecomment-2468205905)


- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
