### PR TITLE
fix(ui): adapt disabled and readonly select styles

### DIFF
--- a/app/assets/stylesheets/src/shared/_components.scss
+++ b/app/assets/stylesheets/src/shared/_components.scss
@@ -125,7 +125,7 @@
     }
 
     &.locked {
-      background-color: $gray-200 !important;
+      background-color: var(--tblr-bg-surface-secondary) !important;
       opacity: 1 !important;
     }
 
@@ -133,7 +133,7 @@
       cursor: default !important;
 
       .item {
-        color: $gray-600 !important;
+        color: var(--tblr-gray-500) !important;
       }
     }
 
@@ -143,7 +143,7 @@
     }
 
     .item {
-      color: $gray-900 !important;
+      color: var(--tblr-body-color) !important;
     }
   }
 


### PR DESCRIPTION
Closes #114.

- [x] Styles for disabled and readonly should be the same as we changed for Text Input ([fix(style): Returned .text-input-component-disabled style](https://github.com/freeats/freeats/pull/85#top))

- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
