### PR TITLE
fix(ui): label's value font size

### DIFF
--- a/app/assets/stylesheets/src/lookbook/_scaffolds.scss
+++ b/app/assets/stylesheets/src/lookbook/_scaffolds.scss
@@ -7,3 +7,7 @@
 .code-green {
   color: $green;
 }
+
+.col-form-label-sm {
+  font-size: 0.875rem;
+}

--- a/app/assets/stylesheets/src/shared/_scaffolds.scss
+++ b/app/assets/stylesheets/src/shared/_scaffolds.scss
@@ -257,3 +257,7 @@ picture {
 svg {
   max-width: unset;
 }
+
+.col-form-label-sm {
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
Closes #73.

seems this problem was because this font size in tabler has value `0.75rem`
![image](https://github.com/user-attachments/assets/6f6eb42d-5a6a-4cba-8a24-2370f7d4b6b4)

in bootstrap
![image](https://github.com/user-attachments/assets/b4992fd0-9e8e-4a50-a2af-9c799afd0a5b)


- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
