### PR TITLE
fix(ui): selectize styles

### DIFF
--- a/app/assets/stylesheets/src/shared/_components.scss
+++ b/app/assets/stylesheets/src/shared/_components.scss
@@ -109,9 +109,6 @@
     --tblr-btn-padding-y: 4px;
   }
 
-  // variable that did not exists in tabler but used by selectize.
-  --bs-border-color-translucent: var(--tblr-border-color-translucent);
-
   .selectize-input {
     border-radius: 4px !important;
     vertical-align: middle; // Fix the height of the component.
@@ -278,12 +275,17 @@
 // The select component dropdown could be anchored to the page body.
 // In this case we moved the dropdown styles out of the `.select-component` class.
 .selectize-dropdown {
+  // variable that did not exists in tabler but used by selectize.
+  --bs-border-color-translucent: var(--tblr-border-color-translucent);
+
   border-radius: 4px;
   box-shadow: none !important;
   color: var(--tblr-gray-800);
 
   .selected {
+    // disabled options.
     background-color: white;
+    color: var(--tblr-gray-800);
 
     // not disabled options.
     &[data-selectable] {
@@ -311,7 +313,6 @@
 
   .selectize-dropdown-emptyoptionlabel {
     text-align: left;
-    height: var(--select_component_min_height);
   }
 }
 

--- a/app/assets/stylesheets/src/shared/_datagrid.scss
+++ b/app/assets/stylesheets/src/shared/_datagrid.scss
@@ -49,12 +49,7 @@
   }
 }
 
-/* table.ats_positions_grid, */
-/* table.ats_dashboard_positions_grid, */
-/* table.tasks_grid, */
-/* table.profile_tasks_grid { */
-/*   td.status { */
-/*     text-align: center; */
-/*     width: 1rem; */
-/*   } */
-/* } */
+.grid-column-35 {
+  min-width: 140px;
+  width: 140px;
+}

--- a/app/grids/ats/team_grid.rb
+++ b/app/grids/ats/team_grid.rb
@@ -38,8 +38,13 @@ class ATS::TeamGrid
 
   column(:email, header: I18n.t("core.email"), order: false, &:email)
 
-  column(:account_status, header: I18n.t("user_accounts.status"), html: true,
-                          order: false) do |model, grid|
+  column(
+    :account_status,
+    header: I18n.t("user_accounts.status"),
+    html: true,
+    order: false,
+    class: "grid-column-35"
+  ) do |model, grid|
     change_access_level_button(model, grid.current_member)
   end
 


### PR DESCRIPTION
Closes #114.

- [x] incorrect text color for disabled option in dropdown menu (white), should be #182433 0.5 opacity (high priority)

![CleanShot 13 11 2024 at 14-01](https://github.com/user-attachments/assets/78db6a3c-de48-4ca2-ae49-967bcf38dc20)

- [x] on Team page, dropdown menu doesn't have borders

![CleanShot 13 11 2024 at 14-08](https://github.com/user-attachments/assets/0fe50cfc-b940-4dba-afc8-0f9b8a8935eb)

- [x] on Team page, chevron overlaps with text in select

![CleanShot 13 11 2024 at 14-29](https://github.com/user-attachments/assets/e46b23b1-9846-4dd5-a7a3-f41efebc0ae2)

- [x] First options in some selects have different bottom padding

![CleanShot 13 11 2024 at 14-10](https://github.com/user-attachments/assets/235c5a16-97b1-4688-9f5e-be94a588e62d)


- [ ] I have reviewed my code in "Files changed" tab.
- [ ] I have re-read the issue and this PR fully resolves it.
