### PR TITLE
fix: return lost code with test

### DIFF
--- a/config/locales/career_site.en.yml
+++ b/config/locales/career_site.en.yml
@@ -13,3 +13,6 @@ en:
       submit_application: Submit application
       successfully_applied: Thank you for applying to the %{position_name} position. We will get back to you as soon as possible.
       view_all: View all positions
+    privacy_link: Privacy Policy
+    recaptcha_error: ReCaptcha verification failed. Please try again.
+    tos_link: Terms of Service

--- a/config/locales/career_site.en.yml
+++ b/config/locales/career_site.en.yml
@@ -14,5 +14,4 @@ en:
       successfully_applied: Thank you for applying to the %{position_name} position. We will get back to you as soon as possible.
       view_all: View all positions
     privacy_link: Privacy Policy
-    recaptcha_error: ReCaptcha verification failed. Please try again.
     tos_link: Terms of Service

--- a/test/controllers/career_site/positions_controller_test.rb
+++ b/test/controllers/career_site/positions_controller_test.rb
@@ -95,6 +95,10 @@ class CareerSite::PositionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show should render position if career_site_enabled" do
+    # These ENV variables are needed to test the display of the footer on career site when they are defined.
+    # The functionality in the absence of these values ​​is checked in the index test.
+    ENV["PRIVACY_LINK"] = "example.com/privacy"
+    ENV["TERMS_LINK"] = "example.com/terms"
     position = positions(:ruby_position)
     tenant = position.tenant
     tenant_slug = tenant.slug
@@ -114,10 +118,18 @@ class CareerSite::PositionsControllerTest < ActionDispatch::IntegrationTest
     get career_site_position_path(tenant_slug:, id: position.slug)
 
     assert_response :success
+
+    ENV["PRIVACY_LINK"] = nil
+    ENV["TERMS_LINK"] = nil
   end
 
   test "index should render positions if career_site_enabled is true and host exists" do
     tenant = tenants(:toughbyte_tenant)
+
+    # Not defined in this test to test the footer when they are missing.
+    # The functionality in the presence of these values ​​is checked in the show test.
+    assert_nil  ENV.fetch("TERMS_LINK", nil)
+    assert_nil  ENV.fetch("PRIVACY_LINK", nil)
 
     get career_site_positions_path(tenant.slug)
 


### PR DESCRIPTION
During the last merge from mine to mirgation-to-tabler, some code was "lost" https://github.com/freeats/freeats/pull/1/commits/1b3fa566548e15e9ae24829a33bf960179555af5

- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
