### PR TITLE
fix(ui): do not reopen select dropdown after turbo action on task's modal

### DIFF
--- a/app/assets/javascript/controllers/select_field_instant_submit_controller.js
+++ b/app/assets/javascript/controllers/select_field_instant_submit_controller.js
@@ -11,6 +11,8 @@ export default class extends Controller {
     // Used explicitly `requestSubmitPolyfilled` because `turbo-instant-submit`
     // works incorrectly when we type something irrelevant and lose focus.
     selectize.on("change", () => {
+      // Turn off focus to prevent reopening the selectize dropdown after turbo action.
+      selectize.$control_input.blur();
       requestSubmitPolyfilled(form);
     });
   }

--- a/app/views/ats/tasks/_main_content.html.slim
+++ b/app/views/ats/tasks/_main_content.html.slim
@@ -60,14 +60,16 @@ ruby:
   .d-flex.flex-wrap.mt-3.column-gap-4
     / Assignee
     = form_with model: task, url: ats_task_path(task, grid:),
-                class: "row flex-fill col-12 col-lg-6 turbo-instant-submit" do |f|
+                class: "row flex-fill col-12 col-lg-6",
+                data: { controller: "select-field-instant-submit" } do |f|
       = f.label :assignee_id, t("core.assignee"), class: label_classes
       .col-lg-9
         = render SingleSelectComponent.new( \
                    f,
                    include_blank: t("core.unassign"),
                    method: :assignee_id,
-                   local: { options: composed_assignee_options } \
+                   local: { options: composed_assignee_options },
+                   data: { deferred_selectize_select_field_instant_submit_target: "selectField" } \
                  )
 
     / Watchers
@@ -98,7 +100,8 @@ ruby:
                                                   humanized_datepicker_target: "datepickerAlt" })
     / Repeat
     = form_with model: task, url: ats_task_path(task, grid:),
-                class: "row flex-fill col-12 col-lg-6 turbo-instant-submit" do |f|
+                class: "row flex-fill col-12 col-lg-6",
+                data: { controller: "select-field-instant-submit" } do |f|
       = f.label :repeat_interval, t("tasks.repeat"), class: label_classes
       .col-lg-9
         = render SingleSelectComponent.new( \
@@ -106,6 +109,7 @@ ruby:
                    method: :repeat_interval,
                    required: true,
                    local: { options: repeat_interval_options },
+                   data: { deferred_selectize_select_field_instant_submit_target: "selectField" } \
                  )
 
   / Fourth row


### PR DESCRIPTION
Closes #47.

old


https://github.com/user-attachments/assets/3273be8a-84c4-49b8-97b1-eb8995bc3f9d



new


https://github.com/user-attachments/assets/7af11ca0-4cc9-4b5a-a2e0-3afed63ad837




- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
