### PR TITLE
fix(ui): badge styles for navbar tasks counter

### DIFF
--- a/app/views/ats/tasks/_navbar_counter.html.slim
+++ b/app/views/ats/tasks/_navbar_counter.html.slim
@@ -2,5 +2,4 @@
 
 span.d-inline-flex id="turbo_navbar_tasks_counter"
   - if pending_tasks_count&.positive?
-    span.badge.bg-light.text-dark
-      = pending_tasks_count
+    span.badge = pending_tasks_count


### PR DESCRIPTION
Closes #16.

navbar tasks counter same as other badges
![image](https://github.com/user-attachments/assets/9b5f0cde-78c7-4f14-a66e-deaa7a58ac15)
![image](https://github.com/user-attachments/assets/2f23ca28-d929-47df-93a3-5a39b13d8cfb)



- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
