### PR TITLE
fix(ui): set select input width automatically depending on placeholder

### DIFF
--- a/app/assets/stylesheets/src/shared/_selectize.scss
+++ b/app/assets/stylesheets/src/shared/_selectize.scss
@@ -3,24 +3,6 @@
 // https://github.com/selectize/selectize.js/issues/1614.
 @import "selectize/dist/css/selectize.bootstrap5";
 
-.selectize-input {
-  input[placeholder] {
-    width: inherit !important;
-  }
-}
-
-.select-in-applicant-profile {
-  .selectize-input,
-  .filter-option-inner {
-    min-height: 40px !important;
-    line-height: 1.5 !important;
-  }
-  &.selectize-control .selectize-input {
-    padding: 7px 14px;
-    border-radius: 0.25rem;
-  }
-}
-
 .selectize-control > .selectize-input {
   cursor: text !important;
 }


### PR DESCRIPTION
Closes #30.

On 320px viewport avatar wraps to the 2nd row, Tabler's navbar doesn't have this issue:

![image](https://github.com/user-attachments/assets/cfa9c0a7-baac-4e5a-81f3-50c874a9d956)


- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
