### PR TITLE
fix: error on setting Sentry context when rodauth is not defined

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   private
 
   def current_account
-    rodauth.rails_account
+    rodauth&.rails_account
   end
 
   def current_member


### PR DESCRIPTION
Can't open candidates page because of 500 error, the reason of this errro is unclear because logs doesn't work due to error:

> Error during failsafe response: key not found: "rodauth"
>   /usr/local/bundle/ruby/3.3.0/gems/rodauth-rails-1.13.0/lib/rodauth/rails/controller_methods.rb:16:in `fetch'
>   /usr/local/bundle/ruby/3.3.0/gems/rodauth-rails-1.13.0/lib/rodauth/rails/controller_methods.rb:16:in `rodauth'
>   /rails/app/controllers/application_controller.rb:21:in `current_account'
>   /rails/app/controllers/application_controller.rb:74:in `set_sentry_account_context'

Can't see the actiual error because of this. I didn't dig deeper why for authorized user rodauth is not initialized. 
