### PR TITLE
fix(ui): restore displaying email message logic

### DIFF
--- a/app/helpers/ats/emails_helper.rb
+++ b/app/helpers/ats/emails_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ATS::EmailsHelper
+  def ats_pretty_email_addresses(email_addresses)
+    email_addresses
+      .map { |name, address| name.present? ? "#{name} <#{address}>" : address }.join(", ")
+  end
+
+  def ats_timelink_in_email_message(controller_name, email_message, possible_id, event_id)
+    profile_activities_path =
+      case controller_name
+      when "candidates"
+        tab_ats_candidate_path(possible_id, :activities, event: event_id)
+      end
+    link_to(t("core.created_time", time: short_time_ago_in_words(email_message.date)),
+            profile_activities_path, data: { turbo: false })
+  end
+end

--- a/app/views/ats/candidates/_profile.html.slim
+++ b/app/views/ats/candidates/_profile.html.slim
@@ -34,6 +34,9 @@
     = render partial: "ats/tasks/tab_counter", locals: { pending_tasks_count: @pending_tab_tasks_count }
   - tab_labels[:emails] = capture
     | Emails
+    - if @email_count.positive?
+      | &nbsp;
+      span.badge = @email_count
 
   - tab_labels[:scorecards] = capture
     | Scorecards

--- a/app/views/ats/candidates/emails_tab.html.slim
+++ b/app/views/ats/candidates/emails_tab.html.slim
@@ -19,3 +19,20 @@ ruby:
                   )
             | Compose
       .col-12#turbo_email_compose_form
+
+    / EMAILS
+    .row
+      .col#turbo_thread_list
+        = render partial: "ats/email_threads/email_thread",
+                 collection: @ordered_candidate_email_threads,
+                 as: :email_thread,
+                 locals: { hashed_avatars: @hashed_avatars,
+                           candidate_ids: @candidate.id,
+                           single_message: @single_message,
+                           controller_name: }
+    .row.mt-3
+      .col
+      - if @single_message
+        = link_to "View all emails", tab_ats_candidate_path(@candidate, :emails)
+      - else
+        = paginate(@ordered_candidate_email_threads, theme: "ats")

--- a/app/views/ats/email_messages/_email_message.html.slim
+++ b/app/views/ats/email_messages/_email_message.html.slim
@@ -1,0 +1,56 @@
+/# locals: (hashed_avatars:, email_message:, candidate_ids:, controller_name:)
+ruby:
+  message = email_message
+  tooltip_text =
+    unless current_member.email_service_linked?
+      t("user_accounts.email_not_linked")
+    end
+
+- if (sanitized_message_body = message.sanitized_body)
+  li.list-group-item.pt-2.px-3.pb-3
+    .email-header.row.mb-3
+      .col-auto
+        - if (sender_avatar = message.sender_avatar_url(hashed_avatars, message.from_addresses.map(&:second))).present?
+          = image_tag sender_avatar
+        - else
+          = render IconComponent.new(:user, class: "email-sender-avatar rounded")
+      .col.text-muted.fw-light
+        | From: #{ats_pretty_email_addresses(message.from_addresses)}
+        br
+        | To: #{ats_pretty_email_addresses(message.to_addresses)}
+        - if message.cc_addresses.length.positive?
+          br
+          | Cc: #{ats_pretty_email_addresses(message.cc_addresses)}
+        - if message.bcc_addresses.length.positive?
+          br
+          | Bcc: #{ats_pretty_email_addresses(message.bcc_addresses)}
+      .col-auto.align-items-start.mt-2.mt-sm-0
+        .hstack.gap-2
+          span.d-inline-block.text-nowrap.text-muted.fw-light [data-bs-toggle="tooltip"
+              data-bs-title=message.date.to_fs(:datetime_full) ]
+            - if (event = message.events.first) && candidate_ids
+              = ats_timelink_in_email_message(controller_name,
+                                              message,
+                                              candidate_ids,
+                                              event.id)
+
+            - else
+              | #{short_time_ago_in_words(message.date)} ago
+
+          - if message.message_id.present? && message.id
+            .d-flex.justify-content-end.email-message-button-group
+              = ats_profile_button_tooltip_wrapper(tooltip: tooltip_text)
+                - if controller_name.present? && (page_id = candidate_ids)
+                  span.d-inline-block title="Copy link" data-bs-toggle="tooltip"
+                    = render IconButtonComponent.new( \
+                               :link,
+                               type: :button,
+                               data: { \
+                                 controller: "copy-to-clipboard",
+                                 clipboard_text: message.url(page_id, controller_name),
+                                 bs_title: "Copied!",
+                                 bs_trigger: "manual",
+                               },
+                             )
+    div
+      = sanitized_message_body


### PR DESCRIPTION
Fix to #263.

restore removed logic to display synced email messages

- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
