### PR TITLE
fix(candidate): restore attaching avatar when we upload candidate via helper

### DIFF
--- a/app/operations/candidates/add.rb
+++ b/app/operations/candidates/add.rb
@@ -6,12 +6,12 @@ class Candidates::Add < ApplicationOperation
   option :actor_account, Types::Instance(Account).optional
   option :method, Types::String.enum("api", "applied", "manual")
   option :params, Types::Strict::Hash.schema(
-    avatar?: Types::Instance(ActionDispatch::Http::UploadedFile),
     alternative_names?: Types::Strict::Array.of(
       Types::Strict::Hash.schema(
         name: Types::Strict::String
       ).optional
     ),
+    avatar?: Types::Instance(ActionDispatch::Http::UploadedFile),
     blacklisted?: Types::Strict::String,
     company?: Types::Strict::String,
     cover_letter?: Types::Strict::String,

--- a/app/operations/candidates/add.rb
+++ b/app/operations/candidates/add.rb
@@ -6,6 +6,7 @@ class Candidates::Add < ApplicationOperation
   option :actor_account, Types::Instance(Account).optional
   option :method, Types::String.enum("api", "applied", "manual")
   option :params, Types::Strict::Hash.schema(
+    avatar?: Types::Instance(ActionDispatch::Http::UploadedFile),
     alternative_names?: Types::Strict::Array.of(
       Types::Strict::Hash.schema(
         name: Types::Strict::String

--- a/test/controllers/api/v1/documents_controller_test.rb
+++ b/test/controllers/api/v1/documents_controller_test.rb
@@ -9,9 +9,10 @@ class API::V1::DocumentsControllerTest < ActionDispatch::IntegrationTest
     url = "https://www.linkedin.com/in/username/"
     full_name = "Sam Smith"
     cv = fixture_file_upload("empty.pdf", "application/pdf")
+    avatar = fixture_file_upload("icon.jpg", "image/jpeg")
 
     assert_difference "Candidate.count" do
-      post api_v1_candidates_url, params: { url:, full_name:, cv: }
+      post api_v1_candidates_url, params: { url:, full_name:, cv:, avatar: }
     end
 
     candidate = Candidate.last
@@ -19,6 +20,7 @@ class API::V1::DocumentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal candidate.full_name, full_name
     assert_equal candidate.links, [url]
     assert_equal candidate.source, "LinkedIn"
+    assert_equal candidate.avatar.attached?, true
   end
 
   test "should not update candidate's source if it is already set and update if not, " \


### PR DESCRIPTION
Closes #298
Fix to #103.

- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
