### PR TITLE
fix(ui): Fix focus issue: clicking on label should focus user_name and company name fields like in Edit email template page

### DIFF
--- a/app/views/settings/company/general_profiles/_company_name.html.slim
+++ b/app/views/settings/company/general_profiles/_company_name.html.slim
@@ -8,7 +8,7 @@
               class: "vstack" do |form|
 
     = render LabeledComponent.new(left_layout_class: "col-12 form-label", right_layout_class: "col-12") do |c|
-      - c.with_label t("settings.company.general.show.full_name_input_label"), for_field: :full_name
+      - c.with_label t("settings.company.general.show.full_name_input_label"), for_field: :tenant_name
       = render TextInputComponent.new(form,
                                       method: :name,
                                       required: true,

--- a/app/views/settings/personal/profiles/_account_info.html.slim
+++ b/app/views/settings/personal/profiles/_account_info.html.slim
@@ -7,7 +7,7 @@
             class: "vstack" do |form|
 
   = render LabeledComponent.new(left_layout_class: "col-12 form-label", right_layout_class: "col-12") do |c|
-    - c.with_label t("settings.person.profile.full_name_input_label"), for_field: :full_name
+    - c.with_label t("settings.person.profile.full_name_input_label"), for_field: :account_name
     = render TextInputComponent.new(form,
                                     method: :name,
                                     size: :small,


### PR DESCRIPTION
Closes #305.

- [x] I have reviewed my code in "Files changed" tab.
- [x] I have re-read the issue and this PR fully resolves it.
